### PR TITLE
Added rico:isSuccessorOf to sh:group organisation:identificationGroup

### DIFF
--- a/memorix-recordtypes/Organisatie.ttl
+++ b/memorix-recordtypes/Organisatie.ttl
@@ -31,12 +31,11 @@ organisation:identificationGroup
 organisation:alternativeGroup
     rdf:type   sh:PropertyGroup ;
     rdfs:label "Ook bekend als"@nl, "Also known as"@en ;
-    sh:order   2.0 ;
-.
+    sh:order   2.0 .
 
 organisation:managementGroup
     rdf:type   sh:PropertyGroup ;
-    rdfs:label "Beheer"@nl, "Management"@en ; ;
+    rdfs:label "Beheer"@nl, "Management"@en ;
     sh:order   3.0 .
 
 rt:Organisation
@@ -59,15 +58,16 @@ rt:Organisation
                                     sh:order             1.0 ;
                                     sh:path              schema:name
                                   ] ;
-    sh:property          [ rdfs:label  "Rechtsopvolger van"@nl, "Successor of"@en ;
-                           dash:editor memorix:LinkedRecordEditor ;
-                           sh:message  "Kies een organisatie uit de lijst."@nl, "Please choose an organisation"@en ;
-                           sh:nodeKind sh:IRI ;
-                           sh:maxCount 100 ;
-                           sh:or       ( [ sh:class rt:Organisation ] ) ;
-                           sh:order    2.0 ;
-                           sh:path     rico:isSuccessorOf ;
-                         ] ;
+    sh:property                   [ rdfs:label  "Rechtsopvolger van"@nl, "Successor of"@en ;
+                                    dash:editor memorix:LinkedRecordEditor ;
+                                    sh:message  "Kies een organisatie uit de lijst."@nl, "Please choose an organisation"@en ;
+                                    sh:nodeKind sh:IRI ;
+                                    sh:group    organisation:identificationGroup ;
+                                    sh:maxCount 100 ;
+                                    sh:or       ( [ sh:class rt:Organisation ] ) ;
+                                    sh:order    2.0 ;
+                                    sh:path     rico:isSuccessorOf ;
+                                  ] ;
     sh:property                   [ rdfs:label           "Alternatieve namen"@nl, "Alternate names"@en ;
                                     memorix:searchWeight 2.0 ;
                                     sh:datatype          xsd:string ;


### PR DESCRIPTION
Memorix Nexus requires fields/properties to be in a group, so I put **Successor of** in **sh:group** **organisation:identificationGroup**