### PR TITLE
add DigitalAssetComponent to File and Image recordtypes

### DIFF
--- a/memorix-recordtypes/Afbeelding.ttl
+++ b/memorix-recordtypes/Afbeelding.ttl
@@ -46,6 +46,7 @@ rt:Image
     a                       memorix:Recordtype, sh:NodeShape ;
     rdfs:label              "Afbeelding"@nl, "Image"@en ;
     rdfs:comment            "Stadsarchief recordtype voor beeldmateriaal"@nl, "Record type for image descriptions"@en ;
+    memorix:hasInformationComponent [ rdf:type memorix:DigitalAssetComponent ] ;
     dc:identifier           "Image" ;
     sh:closed               true ;
     sh:ignoredProperties    ( rdf:type ) ;

--- a/memorix-recordtypes/Akte.ttl
+++ b/memorix-recordtypes/Akte.ttl
@@ -47,6 +47,7 @@ rt:Deed
     dc:identifier        "Deed" ;
     sh:closed            true ;
     sh:ignoredProperties ( rdf:type ) ;
+    memorix:hasInformationComponent [ rdf:type memorix:DigitalAssetComponent ] ;
     sh:property          deed:TitleShape, deed:DocumentaryFormShape, deed:AssociatedWithDateShape, deed:SourceShape, deed:IndexNameShape,
                          deed:HasOrHadSubjectShape, deed:HasOrHadLocation1851Shape, deed:HasOrHadLocation1853Shape, deed:HasOrHadModernLocationShape,
                          deed:AddressHouseNameShape, deed:AddressPlaceShape, deed:AddressDescriptionShape,

--- a/memorix-recordtypes/Bestanddeel.ttl
+++ b/memorix-recordtypes/Bestanddeel.ttl
@@ -59,7 +59,9 @@ rt:File
     memorix:hasInformationComponent [ rdf:type              memorix:TreePathComponent ;
                                       memorix:hasRecordtype rt:Fonds, rt:Series
                                     ] ;
-    memorix:hasInformationComponent [ rdf:type memorix:DepotLocationComponent ] ;
+    memorix:hasInformationComponent [ rdf:type memorix:DepotLocationComponent ;
+                                      rdf:type memorix:DigitalAssetComponent ;
+                                    ] ;
     dc:identifier                   "File" ;
     sh:targetClass                  rt:File ;
     sh:closed                       true ;

--- a/memorix-recordtypes/Persoonsvermelding.ttl
+++ b/memorix-recordtypes/Persoonsvermelding.ttl
@@ -55,6 +55,7 @@ rt:PersonObservation
     dc:identifier        "PersonObservation" ;
     sh:closed            true ;
     sh:ignoredProperties ( rdf:type ) ;
+    memorix:hasInformationComponent [ rdf:type memorix:DigitalAssetComponent ] ;
     sh:property          [ rdfs:label  "Naam"@nl, "Name"@en ;
                            sh:class    pnv:PersonName ;
                            sh:group    personObservation:personListingGroup ;


### PR DESCRIPTION
add `memorix:hasInformationComponent` to File and Image recordtypes, so in Memorix Nexus assets can be linked to records in the user interface.